### PR TITLE
Send _strava4_session to the personal heatmap host

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,9 +245,19 @@ async function handleTileProxyRequest(request, event) {
 
   const stravaCookies = await getStravaCookies(event);
 
+  // The personal heatmap is per-athlete, so its host has to know who is asking.
+  // The CloudFront cookies are only an access grant and carry no identity,
+  // which is why personal-heatmaps-external answers 401 without this. Strava's
+  // own client sends _strava4_session alongside them. The global heatmap is the
+  // same for every athlete, so that host has no use for our identity.
+  const cookie =
+    kind === "personal"
+      ? `${stravaCookies}; _strava4_session=${Env.STRAVA_SESSION}`
+      : stravaCookies;
+
   const proxiedRequest = new Request(proxyUrl, {
     method: "GET",
-    headers: new Headers({ Cookie: stravaCookies }),
+    headers: new Headers({ Cookie: cookie }),
   });
 
   let response = await fetch(proxiedRequest);


### PR DESCRIPTION
Personal heatmap tiles return 401.

The CloudFront cookies we forward are an access grant — they carry no athlete identity. personal-heatmaps-external therefore cannot tell whose heatmap is being requested, which is why it answers 401 rather than the 403 a bad signature would give. Strava's own client sends _strava4_session alongside the CloudFront cookies on these requests (confirmed in devtools).

Scoped to personal requests only: the global heatmap is identical for every athlete, so content-a has no use for our identity and there is no reason to widen where the session cookie travels.

Verified under wrangler dev against a live subscriber account, same build:

  without this change:  /personal 401 (0 bytes),   /global 200 (106K)
  with this change:     /personal 200 (52K PNG),  /global 200 (106K)